### PR TITLE
Remove spaces at the start of the notify label

### DIFF
--- a/utils/alertutils.go
+++ b/utils/alertutils.go
@@ -54,14 +54,11 @@ func Merge(pAlert *models.InternalAlert, alert *models.Alert) {
 	}
 
 	log.Debugf("NOTIFY: %s -> %s", string(pAlert.PrometheusAlert.Labels["notify"]), alert.Notify)
-	var notifyArgv []string
-	if v, ok := pAlert.PrometheusAlert.Labels["notify"]; ok {
-		notifyArgv = strings.Split(string(v), " ")
-	}
-
 	notifyMap := map[string]bool{}
-	for _, value := range notifyArgv {
-		notifyMap[value] = true
+	if v := pAlert.PrometheusAlert.Labels["notify"]; v != "" {
+		for _, value := range strings.Split(string(v), " ") {
+			notifyMap[value] = true
+		}
 	}
 
 	if alert.Notify != "" {
@@ -69,7 +66,7 @@ func Merge(pAlert *models.InternalAlert, alert *models.Alert) {
 	}
 
 	var notifySlice []string
-	for key := range notifyMap {
+	for key, _ := range notifyMap {
 		notifySlice = append(notifySlice, key)
 	}
 

--- a/utils/alertutils.go
+++ b/utils/alertutils.go
@@ -54,7 +54,10 @@ func Merge(pAlert *models.InternalAlert, alert *models.Alert) {
 	}
 
 	log.Debugf("NOTIFY: %s -> %s", string(pAlert.PrometheusAlert.Labels["notify"]), alert.Notify)
-	notifyArgv := strings.Split(string(pAlert.PrometheusAlert.Labels["notify"]), " ")
+	var notifyArgv []string
+	if v, ok := pAlert.PrometheusAlert.Labels["notify"]; ok {
+		notifyArgv = strings.Split(string(v), " ")
+	}
 
 	notifyMap := map[string]bool{}
 	for _, value := range notifyArgv {
@@ -65,8 +68,8 @@ func Merge(pAlert *models.InternalAlert, alert *models.Alert) {
 		notifyMap[alert.Notify] = true
 	}
 
-	notifySlice := make([]string, len(notifyMap))
-	for key, _ := range notifyMap {
+	var notifySlice []string
+	for key := range notifyMap {
 		notifySlice = append(notifySlice, key)
 	}
 

--- a/utils/alertutils.go
+++ b/utils/alertutils.go
@@ -44,7 +44,7 @@ func Key(alert *models.Alert) string {
  * type LabelValue string
  */
 
-// Merge a new hipchat alert into an existing prometheus alert (or an empty prometheus struct if the alert doesn't already exist)
+// Merge a new nagios alert into an existing prometheus alert (or an empty prometheus struct if the alert doesn't already exist)
 func Merge(pAlert *models.InternalAlert, alert *models.Alert) {
 	var alertname string
 	if alert.Type == "host" {

--- a/utils/alertutils_test.go
+++ b/utils/alertutils_test.go
@@ -28,6 +28,17 @@ var testAlert2 = &models.Alert{
 	Note:             "http://reddit.com/",
 }
 
+var testAlert3 = &models.Alert{
+	Type:             "service",
+	Host:             "bar",
+	Service:          "foo",
+	Notify:           "hipchat-bar hipchat-cafe",
+	NotificationType: "PROBLEM",
+	State:            "CRITICAL",
+	Message:          "It's dead jim",
+	Note:             "http://reddit.com/",
+}
+
 func TestKey(t *testing.T) {
 	key := Key(testAlert)
 	key2 := Key(testAlert)
@@ -41,4 +52,19 @@ func TestKey(t *testing.T) {
 	if key == key3 {
 		t.Fatal("Hashes match for different object")
 	}
+}
+
+func TestMerge(t *testing.T) {
+	pAlert := models.InternalAlert{}
+	Merge(&pAlert, testAlert)
+	if got := pAlert.PrometheusAlert.Labels["notify"]; string(got) != testAlert.Notify {
+		t.Errorf("Merge failed: got %#v, expect %#v", got, testAlert.Notify)
+	}
+
+	pAlert = models.InternalAlert{}
+	Merge(&pAlert, testAlert3)
+	if got := pAlert.PrometheusAlert.Labels["notify"]; string(got) != testAlert3.Notify {
+		t.Errorf("Merge failed: got %#v, expect %#v", got, testAlert3.Notify)
+	}
+
 }

--- a/utils/alertutils_test.go
+++ b/utils/alertutils_test.go
@@ -53,14 +53,14 @@ func TestKey(t *testing.T) {
 		t.Fatal("Hashes match for different object")
 	}
 
-	if got := Key(testAlert3); got != key2 {
-		t.Fatalf("Hashes should have matched. got %#v, want %#v", got, key2)
+	if got := Key(testAlert3); got != key3 {
+		t.Fatalf("Hashes should have matched. got %#v, want %#v", got, key3)
 	}
 }
 
 func TestMerge(t *testing.T) {
 	pAlert := models.InternalAlert{}
-	Merge(&pAlert, testAlert)
+	Merge(&pAlert, testAlert2)
 	if got := pAlert.PrometheusAlert.Labels["notify"]; string(got) != testAlert.Notify {
 		t.Errorf("Merge failed: got %#v, want %#v", got, testAlert.Notify)
 	}

--- a/utils/alertutils_test.go
+++ b/utils/alertutils_test.go
@@ -32,7 +32,7 @@ var testAlert3 = &models.Alert{
 	Type:             "service",
 	Host:             "bar",
 	Service:          "foo",
-	Notify:           "hipchat-bar hipchat-cafe",
+	Notify:           "hipchat-cafe",
 	NotificationType: "PROBLEM",
 	State:            "CRITICAL",
 	Message:          "It's dead jim",
@@ -52,19 +52,23 @@ func TestKey(t *testing.T) {
 	if key == key3 {
 		t.Fatal("Hashes match for different object")
 	}
+
+	if got := Key(testAlert3); got != key2 {
+		t.Fatalf("Hashes should have matched. got %#v, want %#v", got, key2)
+	}
 }
 
 func TestMerge(t *testing.T) {
 	pAlert := models.InternalAlert{}
 	Merge(&pAlert, testAlert)
 	if got := pAlert.PrometheusAlert.Labels["notify"]; string(got) != testAlert.Notify {
-		t.Errorf("Merge failed: got %#v, expect %#v", got, testAlert.Notify)
+		t.Errorf("Merge failed: got %#v, want %#v", got, testAlert.Notify)
 	}
 
-	pAlert = models.InternalAlert{}
+	// now test merging a new field:
 	Merge(&pAlert, testAlert3)
-	if got := pAlert.PrometheusAlert.Labels["notify"]; string(got) != testAlert3.Notify {
-		t.Errorf("Merge failed: got %#v, expect %#v", got, testAlert3.Notify)
+	want := "hipchat-bar hipchat-cafe"
+	if got := pAlert.PrometheusAlert.Labels["notify"]; string(got) != want {
+		t.Errorf("Merge failed: got %#v, want %#v", got, want)
 	}
-
 }


### PR DESCRIPTION
Hello,

Great software! I had thought up almost the same concept myself, but I can't prove it, can I. 

So I started testing it, but wondered where the spaces in the notify labels were originating from. I suppose the Merge() is done to make the notify labels unique?

Could you verify my assumptions and generated test case, or send me back into the code. Should the 'Hipchat' in the function documentation stay in?

Thanks again, and I'm really glad I've found it. Kudo's to Matt Bostock for mentioning it in his talk.